### PR TITLE
Added flag to export repository ASCII-tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "copycat"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "copycat"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Rufat Hajizada hajizada.rufat@gmail.com"]
-description = "CLI tool that renders files from a directory as Markdown and copies the result to the clipboard."
+description = "CLI to convert directory contents into Markdown or ASCII tree (respects .gitignore), copy to clipboard or print."
 
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,9 @@
 name = "copycat"
 version = "0.2.0"
 edition = "2021"
+license = "MIT"
 authors = ["Rufat Hajizada hajizada.rufat@gmail.com"]
-description = "CLI to convert directory contents into Markdown or ASCII tree (respects .gitignore), copy to clipboard or print."
+description = "CLI tool to copy your project source code as Markdown to clipboard for context-aware responses from LLMs. "
 
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
 # copycat
 
 ![ci](https://github.com/rhajizada/copycat/actions/workflows/ci.yml/badge.svg)
+![License](https://img.shields.io/badge/License-MIT-green.svg)
 
-**copycat** is a CLI tool written in **Rust** that reads the contents of a
-repository directory (or a single file), formats them into **Markdown**, and
-copies the result to your system clipboard.
-
-Each file is embedded in Markdown as a code block, with language-specific syntax
-highlighting based on file extension or name. Markdown files themselves are
-included as-is. This makes **copycat** especially useful for sharing structured code
-snippets with LLMs, documentation tools, or other developers.
+CLI tool to copy your project source code as Markdown to clipboard for
+context-aware responses from LLMs.
 
 ## Features
 
-- Recursively collects files from a specified directory.
-- Respects `.gitignore` rules.
-- Allows additional exclude patterns via `--exclude`.
-- Can optionally sort files alphabetically before generating Markdown.
+- Recursive file collection from a specified directory or single file
+- Respects .gitignore
+- Custom exclude patterns via --exclude <pattern>
+- Optional sorting (--sort)
+- Output modes:
+  - Markdown: embeds each file as a fenced code block with syntax highlighting
+  - Tree: renders an ASCII-style directory tree (--tree)
+- Choose between copying to clipboard (default) or printing to stdout (--print)
 
 ## Installation
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod tree;
 use anyhow::Result;
 use clap::{ArgAction, Parser};
 use copypasta::{ClipboardContext, ClipboardProvider};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Command-line arguments for the `copycat` application.
 #[derive(Parser, Debug)]
@@ -38,22 +38,22 @@ struct Args {
 }
 
 /// Gather full Markdown of all collected files.
-fn get_contents(path: &PathBuf, excludes: &[String], sort: bool) -> Result<String> {
-    let files = files::collect_files(path.clone(), excludes, sort)
+fn get_contents(path: &Path, excludes: &[String], sort: bool) -> Result<String> {
+    let files = files::collect_files(path.to_path_buf(), excludes, sort)
         .map_err(|e| anyhow::anyhow!("failed to collect files: {}", e))?;
 
     if files.is_empty() {
         anyhow::bail!("no matching files found, nothing to copy");
     }
 
-    let markdown = formatter::generate_markdown(path.as_path(), &files)
+    let markdown = formatter::generate_markdown(path, &files)
         .map_err(|e| anyhow::anyhow!("failed to read files: {}", e))?;
     Ok(markdown)
 }
 
 /// Build an ASCII tree of all collected files & directories.
-fn get_tree(path: &PathBuf, excludes: &[String], sort: bool) -> Result<String> {
-    let tree = tree::collect_tree(path.clone(), excludes, sort)
+fn get_tree(path: &Path, excludes: &[String], sort: bool) -> Result<String> {
+    let tree = tree::collect_tree(path.to_path_buf(), excludes, sort)
         .map_err(|e| anyhow::anyhow!("failed to build tree: {}", e))?;
     Ok(tree)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod files;
 mod formatter;
 mod language;
+mod tree;
 
 use anyhow::Result;
 use clap::{ArgAction, Parser};
@@ -16,7 +17,6 @@ use std::path::PathBuf;
 )]
 struct Args {
     /// Path to repository directory or a single file.
-    /// If directory, copycat recursively collects files.
     path: PathBuf,
 
     /// One or more glob patterns for excluding files (e.g. ".gitignore", "**/*.md").
@@ -27,36 +27,69 @@ struct Args {
     /// Sort files alphabetically.
     #[arg(long = "sort", short = 's', action = ArgAction::SetTrue)]
     sort: bool,
+
+    /// Only output directory tree.
+    #[arg(long = "tree", short = 't', action = ArgAction::SetTrue)]
+    tree: bool,
+
+    /// Print to stdout instead of copying to clipboard.
+    #[arg(long = "print", short = 'p', action = ArgAction::SetTrue)]
+    print: bool,
 }
 
-fn run(args: Args) -> Result<()> {
-    if !args.path.exists() {
-        anyhow::bail!("provided path {} does not exist", args.path.display());
-    }
-
-    let files = files::collect_files(args.path.clone(), &args.excludes, args.sort)
+/// Gather full Markdown of all collected files.
+fn get_contents(path: &PathBuf, excludes: &[String], sort: bool) -> Result<String> {
+    let files = files::collect_files(path.clone(), excludes, sort)
         .map_err(|e| anyhow::anyhow!("failed to collect files: {}", e))?;
 
     if files.is_empty() {
         anyhow::bail!("no matching files found, nothing to copy");
     }
 
-    let markdown = formatter::generate_markdown(&args.path, &files)
+    let markdown = formatter::generate_markdown(path.as_path(), &files)
         .map_err(|e| anyhow::anyhow!("failed to read files: {}", e))?;
+    Ok(markdown)
+}
 
-    let mut ctx = ClipboardContext::new()
-        .map_err(|e| anyhow::anyhow!("failed to create clipboard context: {}", e))?;
-
-    ctx.set_contents(markdown)
-        .map_err(|e| anyhow::anyhow!("failed to set clipboard contents: {}", e))?;
-
-    Ok(())
+/// Build an ASCII tree of all collected files & directories.
+fn get_tree(path: &PathBuf, excludes: &[String], sort: bool) -> Result<String> {
+    let tree = tree::collect_tree(path.clone(), excludes, sort)
+        .map_err(|e| anyhow::anyhow!("failed to build tree: {}", e))?;
+    Ok(tree)
 }
 
 fn main() {
     let args = Args::parse();
-    if let Err(err) = run(args) {
-        eprintln!("{}", err);
+
+    if !args.path.exists() {
+        eprintln!("provided path {} does not exist", args.path.display());
         std::process::exit(1);
+    }
+
+    let output = if args.tree {
+        get_tree(&args.path, &args.excludes, args.sort)
+    } else {
+        get_contents(&args.path, &args.excludes, args.sort)
+    };
+
+    let output = match output {
+        Ok(s) => s,
+        Err(err) => {
+            eprintln!("{}", err);
+            std::process::exit(1);
+        }
+    };
+
+    if args.print {
+        println!("{}", output);
+    } else {
+        let mut ctx = ClipboardContext::new().unwrap_or_else(|e| {
+            eprintln!("failed to create clipboard context: {}", e);
+            std::process::exit(1);
+        });
+        ctx.set_contents(output).unwrap_or_else(|e| {
+            eprintln!("failed to set clipboard contents: {}", e);
+            std::process::exit(1);
+        });
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,0 +1,175 @@
+use crate::files::collect_files;
+use anyhow::{anyhow, Result};
+use std::{ffi::OsStr, path::PathBuf};
+
+/// A node in the in-memory directory tree.
+struct TreeNode {
+    name: String,
+    children: Vec<TreeNode>,
+}
+
+impl TreeNode {
+    /// Create a new node with the given name.
+    pub fn new(name: String) -> Self {
+        TreeNode {
+            name,
+            children: Vec::new(),
+        }
+    }
+
+    /// Insert a sequence of path components into this node.
+    pub fn insert(&mut self, comps: &[&OsStr]) {
+        if comps.is_empty() {
+            return;
+        }
+        let part = comps[0].to_string_lossy().into_owned();
+        // Find existing child or create a new one
+        let child = match self.children.iter_mut().find(|c| c.name == part) {
+            Some(c) => c,
+            None => {
+                self.children.push(TreeNode::new(part.clone()));
+                self.children.last_mut().unwrap()
+            }
+        };
+        // Recurse on the remaining components
+        child.insert(&comps[1..]);
+    }
+
+    /// Recursively sort this node’s children by name.
+    pub fn sort(&mut self) {
+        self.children.sort_by(|a, b| a.name.cmp(&b.name));
+        for child in &mut self.children {
+            child.sort();
+        }
+    }
+
+    /// Render this node and its subtree as an ASCII tree.
+    ///
+    /// `prefix` is the accumulated indent, `is_last` whether this node
+    /// is the last child at its level (to pick └ vs ├).
+    pub fn fmt(&self, prefix: &str, is_last: bool) -> String {
+        // choose the branch pointer
+        let pointer = if is_last { "└── " } else { "├── " };
+
+        // this node’s own line
+        let mut out = format!("{}{}{}\n", prefix, pointer, self.name);
+
+        // prepare prefix for children
+        let new_prefix = if is_last {
+            format!("{}    ", prefix) // pad spaces under a └──
+        } else {
+            format!("{}│   ", prefix) // keep the │ going
+        };
+
+        // render each child
+        let last_idx = self.children.len().saturating_sub(1);
+        for (i, child) in self.children.iter().enumerate() {
+            let last = i == last_idx;
+            out.push_str(&child.fmt(&new_prefix, last));
+        }
+
+        out
+    }
+}
+
+/// Build a directory-tree string of `path`, honoring ignores & excludes.
+pub fn collect_tree(path: PathBuf, excludes: &[String], sort: bool) -> Result<String> {
+    let files = collect_files(path.clone(), excludes, sort)
+        .map_err(|e| anyhow!("failed to collect files: {}", e))?;
+
+    let root_name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(".")
+        .to_string();
+    let mut root = TreeNode::new(root_name.clone());
+
+    for file in files {
+        if let Ok(rel) = file.strip_prefix(&path) {
+            let comps: Vec<&OsStr> = rel.components().map(|c| c.as_os_str()).collect();
+            root.insert(&comps);
+        }
+    }
+
+    if sort {
+        root.sort();
+    }
+
+    let mut output = format!("{}\n", root_name);
+    let last_idx = root.children.len().saturating_sub(1);
+    for (i, child) in root.children.into_iter().enumerate() {
+        let last = i == last_idx;
+        output.push_str(&child.fmt("", last));
+    }
+
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_tree;
+    use std::fs::{self, File};
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_empty_dir() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let tree = collect_tree(root.clone(), &[], true).unwrap();
+        let root_name = root.file_name().unwrap().to_str().unwrap();
+        assert_eq!(tree, format!("{}\n", root_name));
+    }
+
+    #[test]
+    fn test_single_file() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let file = root.join("foo.txt");
+        File::create(&file).unwrap();
+
+        let tree = collect_tree(root.clone(), &[], true).unwrap();
+        let root_name = root.file_name().unwrap().to_str().unwrap();
+        let expected = format!("{}\n└── foo.txt\n", root_name);
+        assert_eq!(tree, expected);
+    }
+
+    #[test]
+    fn test_nested_dirs_sorted() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+
+        // create nested structure
+        fs::create_dir_all(root.join("a/b")).unwrap();
+        File::create(root.join("a/b/file2.rs")).unwrap();
+        File::create(root.join("a/file1.rs")).unwrap();
+
+        let tree = collect_tree(root.clone(), &[], true).unwrap();
+        let root_name = root.file_name().unwrap().to_str().unwrap();
+
+        let expected = format!(
+            "{root}\n\
+└── a\n\
+{i}├── b\n\
+{i}│   └── file2.rs\n\
+{i}└── file1.rs\n",
+            root = root_name,
+            i = "    "
+        );
+        assert_eq!(tree, expected);
+    }
+
+    #[test]
+    fn test_excludes() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+
+        File::create(root.join("keep.rs")).unwrap();
+        File::create(root.join("ignore.rs")).unwrap();
+
+        let tree = collect_tree(root.clone(), &["ignore.rs".into()], true).unwrap();
+        let root_name = root.file_name().unwrap().to_str().unwrap();
+
+        let expected = format!("{r}\n└── keep.rs\n", r = root_name);
+        assert_eq!(tree, expected);
+    }
+}


### PR DESCRIPTION
## Description
- Updated version to `0.2.0`
- Added `tree` module that given arguments generates an ASCII tree of the project respecting gitignores, with tests
- Skipping non `utf-8` formatted files when generating markdown
- Added option to print output instead of copying to clipboard