### PR TITLE
Skipping unreadable files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "copycat"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "copycat"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT"
 authors = ["Rufat Hajizada hajizada.rufat@gmail.com"]


### PR DESCRIPTION
## Description

- Updated `generate_markdown` function to skip unreadable files and print warning on the screen
- Updated version to '0.2.2'